### PR TITLE
Update ptrefdata.sql - PSAEAPPLDEFN Table, RECUSE Field

### DIFF
--- a/sql/ptrefdata.sql
+++ b/sql/ptrefdata.sql
@@ -235,6 +235,11 @@ insert into plan_table (statement_id, object_type, object_name, object_alias, id
 insert into plan_table (statement_id, object_type, object_name, object_alias, id, other_xml) VALUES ('PTREF','VAL','RECUSE','PSRECDEFN',4,'4=Delete');
 insert into plan_table (statement_id, object_type, object_name, object_alias, id, other_xml) VALUES ('PTREF','VAL','RECUSE','PSRECDEFN',8,'8=Selective');
 
+insert into plan_table (statement_id, object_type, object_name, object_alias, id, other_xml) VALUES ('PTREF','VAL','RECUSE','PSAEAPPLDEFN',1,'1=Abort - If non-shared Tables cannot be assigned:');
+insert into plan_table (statement_id, object_type, object_name, object_alias, id, other_xml) VALUES ('PTREF','VAL','RECUSE','PSAEAPPLDEFN',2,'2=Batch Only');
+insert into plan_table (statement_id, object_type, object_name, object_alias, id, other_xml) VALUES ('PTREF','VAL','RECUSE','PSAEAPPLDEFN',4,'4=Share Tables in Online Mode');
+insert into plan_table (statement_id, object_type, object_name, object_alias, id, other_xml) VALUES ('PTREF','VAL','RECUSE','PSAEAPPLDEFN',8,'8=Use Delete for Truncate Table');
+
 insert into plan_table (statement_id, object_type, object_name, object_alias, id, other_xml) VALUES ('PTREF','VAL','AUXFLAGMASK','PSRECDEFN',16,'65536=Tools Table');
 insert into plan_table (statement_id, object_type, object_name, object_alias, id, other_xml) VALUES ('PTREF','VAL','AUXFLAGMASK','PSRECDEFN',17,'131072=Managed Tools Table');
 insert into plan_table (statement_id, object_type, object_name, object_alias, id, other_xml) VALUES ('PTREF','VAL','AUXFLAGMASK','PSRECDEFN',18,'262144=In use, but not yet sure what it does!');


### PR DESCRIPTION
Hi David, I just found out what the RECUSE field values are for PSAEAPPLDEFN (Main Application Engine Tools Table)

I didn't download your repository to my own PC as I don't have SYSADM access to a PS Database here where I work. So I just reviewed your code and am guessing this is how the PSAEAPPLDEFN page would be updated with these values.

Neil